### PR TITLE
Regression conda env really only needs gsx.

### DIFF
--- a/src/prod/Makefile
+++ b/src/prod/Makefile
@@ -90,7 +90,7 @@ regression-setup:
 	git clone git@github.com:nsidc/pmesdr_regression_data.git
 
 conda-env:
-	conda create -y -n $(CONDAENV) netcdf4 nose numpy
+	conda create -y -n $(CONDAENV) gsx nose
 
 quick-regression:
 	${PMESDR_TOP_DIR}/regression_scripts/run_regression.sh quick $(CONDAENV)


### PR DESCRIPTION
Because gsx already depends on netcdf4 and numpy.